### PR TITLE
Feature: Favicon as KV pair in config.yml

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -7,6 +7,7 @@ description: |
   aka @ironicbadger
   Father. Educator. Tinkerer.
 avatar: "assets/avatar.jpg"
+favicon: "assets/favicon.png"
 
 # Theme selection
 theme: "default"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Subtitle      string     `yaml:"subtitle"`
 	Description   string     `yaml:"description"`
 	Avatar        string     `yaml:"avatar"`
+	Favicon        string     `yaml:"favicon"`
 	Theme         string     `yaml:"theme"`
 	Background    Background `yaml:"background"`
 	Links         []Link     `yaml:"links"`

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -258,6 +258,16 @@ func (g *Generator) copyUserAssets() error {
 		}
 	}
 
+	if g.cfg.Favicon != "" && !strings.HasPrefix(g.cfg.Favicon, "http://") && !strings.HasPrefix(g.cfg.Favicon, "https://") {
+		srcFavicon := filepath.Join("assets", g.cfg.Favicon)
+		if _, err := os.Stat(srcFavicon); err == nil {
+			dstFavicon := filepath.Join(g.outputDir, g.cfg.Favicon)
+			if err := copyFile(srcFavicon, dstFavicon); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Copy user assets directory if it exists
 	userAssetsDir := "assets"
 	if _, err := os.Stat(userAssetsDir); err == nil {

--- a/themes/default/template.html
+++ b/themes/default/template.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Config.Name}}</title>
     <meta name="description" content="{{.Config.Description}}">
-    <link rel="icon" type="image/png" href="assets/favicon.png">
+    {{if .Config.Favicon}}
+    <link rel="icon" type="image/png" href="{{.Config.Favicon}}">
+    {{end}}
 
     {{/* Theme stylesheets */}}
     {{range .ThemeStyles}}


### PR DESCRIPTION
add `favicon` kv pair to specify favicon in config value for `favicon` can be:
    a local files located inside `assets` directory
    URI to a resource which will not be copied during build process
No favicon is used if none is specified in config.yml

#6 