### PR TITLE
Feature: Add web analytics via Google analytics and Goatcounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ docker run -d -p 8080:80 ghcr.io/ironicbadger/linkme:latest
 ## Configuration
 
 Edit `config/config.yaml` to customize your links and appearance.
+
+### Analytics
+
+Google analytics and Goatcounter currently allowed
+
+If `Goatcounter.selfhosted=True`: id is used as domain therefore user need to provide FQDN
+in ID
+else: `id` is prepended to `.goatcounter.com`

--- a/README.md
+++ b/README.md
@@ -26,8 +26,24 @@ Edit `config/config.yaml` to customize your links and appearance.
 
 ### Analytics
 
-Google analytics and Goatcounter currently allowed
+Supported: Google Analytics, GoatCounter, and Plausible.
 
-If `Goatcounter.selfhosted=True`: id is used as domain therefore user need to provide FQDN
-in ID
-else: `id` is prepended to `.goatcounter.com`
+Example config:
+
+```yaml
+analytics:
+  google:
+    id: "G-XXXXXXX"
+  goatcounter:
+    id: "example"
+    selfhosted: false
+  plausible:
+    domain: "example.com" # tracked site
+    script_url: "" # optional; set to your self-hosted instance URL (e.g. https://plausible.example.com/js/script.js)
+```
+
+GoatCounter:
+If `selfhosted: true`, `id` must be the full host (FQDN) of your instance. Otherwise `id` is used as the subdomain on `goatcounter.com`.
+
+Plausible:
+Set `domain` to the site you want to track. For self-hosted, set `script_url` to your instance’s script URL.

--- a/config/config.yml
+++ b/config/config.yml
@@ -8,6 +8,14 @@ description: |
   Father. Educator. Tinkerer.
 avatar: "assets/avatar.jpg"
 
+## Analytics
+analytics:
+  google:
+    id: "G-TEST123"
+  goatcounter:
+    id: "test-goat"
+
+
 # Theme selection
 theme: "default"
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,9 +11,10 @@ avatar: "assets/avatar.jpg"
 ## Analytics
 analytics:
   google:
-    id: "G-TEST123"
+    id: ""
   goatcounter:
-    id: "test-goat"
+    id: ""
+    selfhosted: false
 
 
 # Theme selection

--- a/config/config.yml
+++ b/config/config.yml
@@ -15,6 +15,9 @@ analytics:
   goatcounter:
     id: ""
     selfhosted: false
+  plausible:
+    domain: "" # tracked site
+    script_url: ""
 
 
 # Theme selection

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,20 @@ type Config struct {
 	Links         []Link     `yaml:"links"`
 	Sections      []Section  `yaml:"sections"`
 	Socials       []Social   `yaml:"socials"`
+	Analytics     Analytics `yaml:"analytics"`
+}
+
+type Analytics struct {
+	Google      *GoogleAnalytics `yaml:"google"`
+	GoatCounter *GoatCounter     `yaml:"goatcounter"`
+}
+
+type GoogleAnalytics struct {
+	ID string `yaml:"id"`
+}
+
+type GoatCounter struct {
+	ID string `yaml:"id"`
 }
 
 type Background struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 type Analytics struct {
 	Google      *GoogleAnalytics `yaml:"google"`
 	GoatCounter *GoatCounter     `yaml:"goatcounter"`
+	Plausible   *Plausible       `yaml:"plausible"`
 }
 
 type GoogleAnalytics struct {
@@ -33,6 +34,11 @@ type GoogleAnalytics struct {
 type GoatCounter struct {
 	ID          string `yaml:"id"`
 	Selfhosted  bool   `yaml:"selfhosted"`
+}
+
+type Plausible struct {
+	Domain    string `yaml:"domain"`
+	ScriptURL string `yaml:"script_url"`
 }
 
 type Background struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,8 @@ type GoogleAnalytics struct {
 }
 
 type GoatCounter struct {
-	ID string `yaml:"id"`
+	ID          string `yaml:"id"`
+	Selfhosted  bool   `yaml:"selfhosted"`
 }
 
 type Background struct {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -31,6 +31,8 @@ type TemplateData struct {
 	ThemeStyles     []string // CSS files to include
 	ThemeScripts    []string // JS files to include
 	BuildDate       string   // Date when the site was generated
+	Analytics 		*config.Analytics
+
 }
 
 type SectionData struct {
@@ -122,6 +124,7 @@ func (g *Generator) prepareTemplateData() *TemplateData {
 		ThemeStyles:     g.theme.Styles,
 		ThemeScripts:    g.theme.Scripts,
 		BuildDate:       time.Now().Format("Jan 2, 2006"),
+		Analytics:       &g.cfg.Analytics,
 	}
 
 	// Prepare links with SVG icons

--- a/themes/default/template.html
+++ b/themes/default/template.html
@@ -7,6 +7,32 @@
     <meta name="description" content="{{.Config.Description}}">
     <link rel="icon" type="image/png" href="assets/favicon.png">
 
+
+    {{/* Analytics */}}
+    {{/* GoatCounter */}}
+    {{ with .Analytics.GoatCounter }}
+    <script data-goatcounter="https://{{ .ID }}.goatcounter.com/count" async src="//gc.zgo.at/count.js">
+    </script>
+    {{ end }}
+
+    {{/* Google analytics */}}
+    {{ with .Analytics.Google }}
+    <script defer src="https://www.googletagmanager.com/gtag/js?id={{ .ID }}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+        dataLayer.push(arguments);
+        }
+
+        gtag('js', new Date());
+        gtag('config', '{{ .ID }}');
+    });
+    </script>
+    {{ end }}
+
+
+
     {{/* Theme stylesheets */}}
     {{range .ThemeStyles}}
     <link rel="stylesheet" href="{{.}}">

--- a/themes/default/template.html
+++ b/themes/default/template.html
@@ -7,16 +7,24 @@
     <meta name="description" content="{{.Config.Description}}">
     <link rel="icon" type="image/png" href="assets/favicon.png">
 
-
     {{/* Analytics */}}
     {{/* GoatCounter */}}
+    {{/* with avoids nil dereference which results in panic */}}
     {{ with .Analytics.GoatCounter }}
+    {{ if .ID }}
+    {{ if .Selfhosted }}
+    <script data-goatcounter="https://{{ .ID }}/count" async src="//gc.zgo.at/count.js">
+    </script>
+    {{ else }}
     <script data-goatcounter="https://{{ .ID }}.goatcounter.com/count" async src="//gc.zgo.at/count.js">
     </script>
+    {{ end }}
+    {{ end }}
     {{ end }}
 
     {{/* Google analytics */}}
     {{ with .Analytics.Google }}
+    {{ if .ID }}
     <script defer src="https://www.googletagmanager.com/gtag/js?id={{ .ID }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -24,14 +32,12 @@
         function gtag() {
         dataLayer.push(arguments);
         }
-
         gtag('js', new Date());
         gtag('config', '{{ .ID }}');
     });
     </script>
     {{ end }}
-
-
+    {{ end }}
 
     {{/* Theme stylesheets */}}
     {{range .ThemeStyles}}

--- a/themes/default/template.html
+++ b/themes/default/template.html
@@ -22,6 +22,17 @@
     {{ end }}
     {{ end }}
 
+    {{/* Plausible analytics */}}
+    {{ with .Analytics.Plausible }}
+    {{ if .Domain }}
+    {{ if .ScriptURL }}
+    <script defer data-domain="{{ .Domain }}" src="{{ .ScriptURL }}"></script>
+    {{ else }}
+    <script defer data-domain="{{ .Domain }}" src="https://plausible.io/js/script.js"></script>
+    {{ end }}
+    {{ end }}
+    {{ end }}
+
     {{/* Google analytics */}}
     {{ with .Analytics.Google }}
     {{ if .ID }}


### PR DESCRIPTION
Added web analytics using:

- [x] Google analytics
- [x] Goatcounter

Both can be configured via `config.yml`

If `goatcounter.selfhosted=true`, then `goatcounter.id` is treated as FQDN for goatcounter
Else, `goatcounter.id` is prepended to `.goatcounter.com`

#8 