### PR TITLE
Feature: Add support for lucide.dev icons

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -37,6 +37,7 @@ links:
   - title: "blog.ktz.me"
     url: "https://blog.ktz.me"
     icon: "rss"
+    icon-provider: "simpleicon"
     color: "#404040"
 
   - title: "Perfect Media Server"
@@ -47,11 +48,13 @@ links:
   - title: "GitHub: Ironicbadger"
     url: "https://github.com/IronicBadger"
     icon: "github"
+    icon-provider: "simpleicon"
     color: "#0a0a0a"
 
   - title: "YouTube: KTZ Systems"
     url: "https://www.youtube.com/@ktzsystems"
     icon: "youtube"
+    icon-provider: "simpleicon"
     color: "#dc2626"
 
   - title: "YouTube: Tailscale"
@@ -62,6 +65,7 @@ links:
   - title: "YouTube: Personal Stuff"
     url: "https://www.youtube.com/@alexkretzschmar"
     icon: "youtube"
+    icon-provider: "simpleicon"
     color: "#dc2626"
 
 # Sections with headings
@@ -80,14 +84,18 @@ sections:
 # Social links (small icons)
 socials:
   - icon: "mastodon"
+    icon-provider: "simpleicon"
     url: "https://techhub.social/@ironicbadger"
     color: "#6364FF"
   - icon: "x"
+    icon-provider: "simpleicon"
     url: "https://twitter.com/ironicbadger"
     color: "#FFFFFF"
   - icon: "reddit"
+    icon-provider: "simpleicon"
     url: "https://www.reddit.com/user/Ironicbadger"
     color: "#FF4500"
   - icon: "linkedin"
+    icon-provider: "simpleicon"
     url: "https://www.linkedin.com/in/alex-kretzschmar/"
     color: "#0A66C2"

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.13.0 // indirect
+require (
+	github.com/kaugesaar/lucide-go v0.10.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/kaugesaar/lucide-go v0.10.0 h1:YKCantl8SHndMXWwnnxYSOaKvy31i5tE7LK3GCefQjE=
+github.com/kaugesaar/lucide-go v0.10.0/go.mod h1:XewB1pV8an9xmQ3+x7riCwjCtCrwfeUTaI3fiBhfjbY=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,13 +13,13 @@ type Config struct {
 	Subtitle      string     `yaml:"subtitle"`
 	Description   string     `yaml:"description"`
 	Avatar        string     `yaml:"avatar"`
-	Favicon        string     `yaml:"favicon"`
+	Favicon       string     `yaml:"favicon"`
 	Theme         string     `yaml:"theme"`
 	Background    Background `yaml:"background"`
 	Links         []Link     `yaml:"links"`
 	Sections      []Section  `yaml:"sections"`
 	Socials       []Social   `yaml:"socials"`
-	Analytics     Analytics `yaml:"analytics"`
+	Analytics     Analytics  `yaml:"analytics"`
 }
 
 type Analytics struct {
@@ -33,8 +33,8 @@ type GoogleAnalytics struct {
 }
 
 type GoatCounter struct {
-	ID          string `yaml:"id"`
-	Selfhosted  bool   `yaml:"selfhosted"`
+	ID         string `yaml:"id"`
+	Selfhosted bool   `yaml:"selfhosted"`
 }
 
 type Plausible struct {
@@ -50,11 +50,12 @@ type Background struct {
 }
 
 type Link struct {
-	Title   string `yaml:"title"`
-	URL     string `yaml:"url"`
-	Icon    string `yaml:"icon"`    // Simple Icons slug
-	IconURL string `yaml:"iconUrl"` // Custom icon URL (overrides icon)
-	Color   string `yaml:"color"`   // hex color for button
+	Title        string `yaml:"title"`
+	URL          string `yaml:"url"`
+	Icon         string `yaml:"icon"`          // Simple Icons slug
+	IconURL      string `yaml:"iconUrl"`       // Custom icon URL (overrides icon)
+	IconProvider string `yaml:"icon-provider"` // Simpleicon (default) or lucide.dev
+	Color        string `yaml:"color"`         // hex color for button
 }
 
 type Section struct {
@@ -63,9 +64,10 @@ type Section struct {
 }
 
 type Social struct {
-	Icon  string `yaml:"icon"`  // Simple Icons slug
-	URL   string `yaml:"url"`
-	Color string `yaml:"color"` // hex color for icon
+	Icon         string `yaml:"icon"`          // Simple Icons slug
+	IconProvider string `yaml:"icon-provider"` // Simpleicon (default) or lucide.dev
+	URL          string `yaml:"url"`
+	Color        string `yaml:"color"` // hex color for icon
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -132,7 +132,7 @@ func (g *Generator) prepareTemplateData() *TemplateData {
 		data.Links = append(data.Links, LinkData{
 			Title:   link.Title,
 			URL:     link.URL,
-			IconSVG: template.HTML(GetSimpleIcon(link.Icon)),
+			IconSVG: template.HTML(GetIconSVG(link.Icon, link.IconProvider)),
 			IconURL: link.IconURL,
 			Color:   link.Color,
 		})

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -147,7 +147,7 @@ func (g *Generator) prepareTemplateData() *TemplateData {
 			sectionData.Links = append(sectionData.Links, LinkData{
 				Title:   link.Title,
 				URL:     link.URL,
-				IconSVG: template.HTML(GetSimpleIcon(link.Icon)),
+				IconSVG: template.HTML(GetIconSVG(link.Icon, link.IconProvider)),
 				IconURL: link.IconURL,
 				Color:   link.Color,
 			})
@@ -159,7 +159,7 @@ func (g *Generator) prepareTemplateData() *TemplateData {
 	for _, social := range g.cfg.Socials {
 		data.Socials = append(data.Socials, SocialData{
 			URL:     social.URL,
-			IconSVG: template.HTML(GetSimpleIcon(social.Icon)),
+			IconSVG: template.HTML(GetIconSVG(social.Icon, social.IconProvider)),
 			Color:   social.Color,
 		})
 	}

--- a/internal/generator/icons.go
+++ b/internal/generator/icons.go
@@ -4,6 +4,8 @@ import (
 	"embed"
 	"encoding/json"
 	"strings"
+
+	"github.com/kaugesaar/lucide-go"
 )
 
 //go:embed icons.json
@@ -50,10 +52,7 @@ func GetIconSVG(iconName, provider string) string {
 		return GetSimpleIcon(iconName)
 
 	case "lucide":
-		if svg, ok := getLucideIconSVG(iconName); ok {
-			return svg
-		}
-		return placeholderSVG
+		return getLucideIconSVG(iconName)
 
 	default:
 		return placeholderSVG
@@ -65,9 +64,19 @@ func normalizeSlug(slug string) string {
 }
 
 // TODO: wire this to lucide-go module
-func getLucideIconSVG(name string) (string, bool) {
-	_ = name
-	return "", false
+func getLucideIconSVG(slug string) string {
+	icon := lucide.Icon(slug, map[string]any{
+		"size":        24,
+		"strokeWidth": 2,
+		"color":       "currentColor",
+	})
+
+	// lucide.Icon returns template.HTML
+	if icon == "" {
+		return placeholderSVG
+	}
+
+	return string(icon)
 }
 
 // GetSimpleIcon returns an SVG string for the given icon slug

--- a/internal/generator/icons.go
+++ b/internal/generator/icons.go
@@ -34,8 +34,40 @@ func init() {
 
 	iconsData = make(map[string]IconData)
 	for _, icon := range icons {
-		iconsData[icon.Slug] = icon
+		// to avoid slug mismatch when looking up in simpleicons
+		iconsData[strings.ToLower(icon.Slug)] = icon
 	}
+}
+
+const placeholderSVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/></svg>`
+
+func GetIconSVG(iconName, provider string) string {
+	iconName = normalizeSlug(iconName)
+	iconProvider := strings.TrimSpace(strings.ToLower(provider))
+
+	switch iconProvider {
+	case "", "simpleicon":
+		return GetSimpleIcon(iconName)
+
+	case "lucide":
+		if svg, ok := getLucideIconSVG(iconName); ok {
+			return svg
+		}
+		return placeholderSVG
+
+	default:
+		return placeholderSVG
+	}
+}
+
+func normalizeSlug(slug string) string {
+	return strings.ToLower(strings.TrimSpace(slug))
+}
+
+// TODO: wire this to lucide-go module
+func getLucideIconSVG(name string) (string, bool) {
+	_ = name
+	return "", false
 }
 
 // GetSimpleIcon returns an SVG string for the given icon slug
@@ -44,7 +76,7 @@ func GetSimpleIcon(slug string) string {
 	icon, ok := iconsData[slug]
 	if !ok {
 		// Return a placeholder circle if icon not found
-		return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="10"/></svg>`
+		return placeholderSVG
 	}
 
 	return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="` + icon.Path + `"/></svg>`


### PR DESCRIPTION
Using [https://github.com/kaugesaar/lucide-go](lucide-go) module by kaugesaar

Implemented:

- `icon-provider` parameter in `config.yml`
- If `icon-provider` doesn't exist or is empty string or equals "simpleicon", use simpleicon as provider
- If `icon-provider` equals "lucide", lucide.dev icon is used

#11 
